### PR TITLE
Render schema as table

### DIFF
--- a/assets/js/schema-table.js
+++ b/assets/js/schema-table.js
@@ -1,0 +1,25 @@
+import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
+
+function fillTable(table, schema) {
+    for (const [name, def] of Object.entries(schema)) {
+        const row = document.createElement("tr");
+
+        const nameCell = document.createElement("td");
+        nameCell.textContent = name;
+        row.appendChild(nameCell);
+
+        const descriptionCell = document.createElement("td");
+        if (def.properties) {
+            const subTable = document.createElement("table");
+            fillTable(subTable, def.properties);
+            descriptionCell.appendChild(subTable);
+        } else {
+            descriptionCell.innerHTML = marked.parse(def.description || '');
+        }
+        row.appendChild(descriptionCell);
+
+        table.appendChild(row);
+    }
+}
+
+fillTable(document.getElementById("schema-table"), schema);

--- a/content/schema.md
+++ b/content/schema.md
@@ -10,8 +10,7 @@ order: 5
 
     
 
-    function fillTable(id, schema) {
-        const table = document.getElementById(id);
+    function fillTable(table, schema) {
         for (const [name, def] of Object.entries(schema)) {
             const row = document.createElement("tr");
 
@@ -20,13 +19,19 @@ order: 5
             row.appendChild(nameCell);
 
             const descriptionCell = document.createElement("td");
-            descriptionCell.textContent = def.description;
+            if (def.properties) {
+                const subTable = document.createElement("table");
+                fillTable(subTable, def.properties);
+                descriptionCell.appendChild(subTable);
+            } else {
+                descriptionCell.textContent = def.description;
+            }
             row.appendChild(descriptionCell);
 
             table.appendChild(row);
         }
     }
 
-    fillTable("schema-table", schema);
+    fillTable(document.getElementById("schema-table"), schema);
 
 </script>

--- a/content/schema.md
+++ b/content/schema.md
@@ -4,11 +4,12 @@ order: 5
 ---
 
 <table id="schema-table"></table>
-
 <script>
-    const schema = {{ site.data.schemas.deployments-schema.properties.deployment.properties | jsonify }};
+const schema = {{ site.data.schemas.deployments-schema.properties.deployment.properties | jsonify }};
+</script>
 
-    
+<script type="module">
+    import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
 
     function fillTable(table, schema) {
         for (const [name, def] of Object.entries(schema)) {
@@ -24,7 +25,7 @@ order: 5
                 fillTable(subTable, def.properties);
                 descriptionCell.appendChild(subTable);
             } else {
-                descriptionCell.textContent = def.description;
+                descriptionCell.innerHTML = marked.parse(def.description || '');
             }
             row.appendChild(descriptionCell);
 

--- a/content/schema.md
+++ b/content/schema.md
@@ -1,0 +1,32 @@
+---
+title: Schema
+order: 5
+---
+
+<table id="schema-table"></table>
+
+<script>
+    const schema = {{ site.data.schemas.deployments-schema.properties.deployment.properties | jsonify }};
+
+    
+
+    function fillTable(id, schema) {
+        const table = document.getElementById(id);
+        for (const [name, def] of Object.entries(schema)) {
+            const row = document.createElement("tr");
+
+            const nameCell = document.createElement("td");
+            nameCell.textContent = name;
+            row.appendChild(nameCell);
+
+            const descriptionCell = document.createElement("td");
+            descriptionCell.textContent = def.description;
+            row.appendChild(descriptionCell);
+
+            table.appendChild(row);
+        }
+    }
+
+    fillTable("schema-table", schema);
+
+</script>

--- a/content/schema.md
+++ b/content/schema.md
@@ -7,32 +7,4 @@ order: 5
 <script>
 const schema = {{ site.data.schemas.deployments-schema.properties.deployment.properties | jsonify }};
 </script>
-
-<script type="module">
-    import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
-
-    function fillTable(table, schema) {
-        for (const [name, def] of Object.entries(schema)) {
-            const row = document.createElement("tr");
-
-            const nameCell = document.createElement("td");
-            nameCell.textContent = name;
-            row.appendChild(nameCell);
-
-            const descriptionCell = document.createElement("td");
-            if (def.properties) {
-                const subTable = document.createElement("table");
-                fillTable(subTable, def.properties);
-                descriptionCell.appendChild(subTable);
-            } else {
-                descriptionCell.innerHTML = marked.parse(def.description || '');
-            }
-            row.appendChild(descriptionCell);
-
-            table.appendChild(row);
-        }
-    }
-
-    fillTable(document.getElementById("schema-table"), schema);
-
-</script>
+<script type="module" src="/assets/js/schema-table.js"></script>


### PR DESCRIPTION
- Fix #38
- Because of the limited width, and some long field names, the rendering at the bottom isn't great, but I wouldn't over-engineer this right now.
- Demo markdown rendering on the front end.
- Possible additions:
  - valid enum values?
  - tiers? (Requires https://github.com/opendp/deployments-registry-data/pull/55, which adds tier info to schema.)