### PR TITLE
#165 Show Pending status deployments in the registry

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,7 @@ published_statuses:
   - "Approved"
   - "Approved (Update Requested)"
   - "Approved (Pending)"
+  - "Pending"
 
 exclude:
   - eslint.config.mjs


### PR DESCRIPTION
Add **Pending** to the `published_statuses` whitelist in `_config.yml` so that deployments awaiting board review are visible in the table, visualizations, and TSV download.

Currently 19 deployments have `Pending` status and will become visible with this change.

Closes #165