### PR TITLE
Remove "Converted" and "Pending" from published_statuses (fixes #168)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,11 +66,9 @@ defaults:
 # Deployment statuses shown in the public UI (whitelist).
 # See NIST IR 8588 §5.1: https://nvlpubs.nist.gov/nistpubs/ir/2025/NIST.IR.8588.ipd.pdf#page=21
 published_statuses:
-  - "Converted"
   - "Approved"
   - "Approved (Update Requested)"
   - "Approved (Pending)"
-  - "Pending"
 
 exclude:
   - eslint.config.mjs


### PR DESCRIPTION
Brings the UI into agreement with the whitepaper ([NIST IR 8588](https://nvlpubs.nist.gov/nistpubs/ir/2025/NIST.IR.8588.ipd.pdf) §5.1): only approved submissions should be publicly shown.

Removes `Converted` and `Pending` from `published_statuses`. Final whitelist: `Approved`, `Approved (Update Requested)`, `Approved (Pending)`.

⚠️ Current `_data` has 0 `Approved*` records, so merging alone empties the registry. Land together with data-repo approvals + submodule bump.

Closes #168